### PR TITLE
Add `decodeHeaderDynsym` for decoding dynamic symbol tables

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@
     (i.e., in a `.gnu.version_d` section) rather than a version requirement
     (i.e., in a `.gnu.version_r` section). The new `dynVersionDefMap` function
     can be used to construct the `VersionDefMap`.
+  * Add a `decodeHeaderDynsym` function that computes the dynamic symbol table
+    directly from an `ElfHeaderInfo`, much like `decodeHeaderSymtab` computes
+    the static symbol table.
 
 ## 0.32 -- *2018 Sep 17*
 

--- a/src/Data/ElfEdit/Prim/HeaderInfo.hs
+++ b/src/Data/ElfEdit/Prim/HeaderInfo.hs
@@ -141,7 +141,7 @@ phdrByIndex :: ElfHeaderInfo w -- ^ Information for parsing
             -> Word16 -- ^ Index
             -> Phdr w
 phdrByIndex e i
-    | i >= phdrCount e = error $ "Program header out of range."
+    | i >= phdrCount e = error "Program header out of range."
     | otherwise =
         case strictRunGetOrFail (getPhdr hdr i) b of
           Left _ -> error "phdrByIndex failed."
@@ -259,7 +259,7 @@ decodeHeaderSymtab :: ElfHeaderInfo w -> Maybe (Either SymtabError (Symtab w))
 decodeHeaderSymtab elf = elfClassInstances (headerClass (header elf)) $ do
   let shdrs = headerShdrs elf
   let symtabs = V.filter (\s -> shdrType s == SHT_SYMTAB) shdrs
-  when (V.length symtabs == 0) $ Nothing
+  when (V.length symtabs == 0) Nothing
   Just $ decodeSymbolTable elf symtabs
 
 -- | Decodes the dynamic symbol table using ELF header info.
@@ -279,7 +279,7 @@ decodeHeaderDynsym :: ElfHeaderInfo w -> Maybe (Either SymtabError (Symtab w))
 decodeHeaderDynsym elf = elfClassInstances (headerClass (header elf)) $ do
   let shdrs = headerShdrs elf
   let dynSymtabs = V.filter (\s -> shdrType s == SHT_DYNSYM) shdrs
-  when (V.length dynSymtabs == 0) $ Nothing
+  when (V.length dynSymtabs == 0) Nothing
   Just $ decodeSymbolTable elf dynSymtabs
 
 -- | Decodes the symbol table from the section headers using the given ELF

--- a/src/Data/ElfEdit/Prim/SymbolTable.hs
+++ b/src/Data/ElfEdit/Prim/SymbolTable.hs
@@ -301,23 +301,31 @@ data SymtabError
    | MultipleSymtabs
      -- ^ Multiple symbol tables in binary.
      --
-     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab`
+     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab` and
+     -- `Data.ElfEdit.Prim.decodeHeaderDynsym`
    | InvalidSymtabFileRange
      -- ^ Invalid symbol table link
      --
-     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab`
+     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab` and
+     -- `Data.ElfEdit.Prim.decodeHeaderDynsym`
+
    | InvalidSymtabLink
      -- ^ Invalid string table file range
      --
-     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab`
+     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab` and
+     -- `Data.ElfEdit.Prim.decodeHeaderDynsym`
+
    | InvalidSymtabLocalCount
      -- ^ Invalid symbol table local count.
      --
-     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab`
+     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab` and
+     -- `Data.ElfEdit.Prim.decodeHeaderDynsym`
+
    | InvalidStrtabFileRange
      -- ^ Invalid string table file range
      --
-     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab`
+     -- Raised in `Data.ElfEdit.Prim.decodeHeaderSymtab` and
+     -- `Data.ElfEdit.Prim.decodeHeaderDynsym`
 
 instance Show SymtabError where
   show (InvalidName idx msg) = "Error parsing symbol " ++ show idx ++ " name: " ++ show msg


### PR DESCRIPTION
Just like `decodeHeaderSymtab` decodes the static function symbol table, `decodeHeaderDynsym` serves the same role for dynamic function symbol tables. The functionality of `decodeHeaderDynsym` largely overlaps with the niche that the `dynamicEntries`/`dynSymEntry` functions provide, so I have included a comparison to those functions in the Haddocks for `decodeHeaderDynsym`.

This will be useful for eventual fixes for GaloisInc/macaw#277 and GaloisInc/macaw-loader#12.