### PR TITLE
Cleanup README and .gitignore, use non-deprecated actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,14 +21,14 @@ jobs:
       run: |
         cp cabal.project.werror cabal.project.local
         cp cabal.project.freeze.ghc-${{ matrix.ghc-ver }} cabal.project.freeze
-    - uses: haskell/actions/setup@v1
+    - uses: haskell-actions/setup@v2
       id: setup-haskell
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         cabal-version: ${{ matrix.cabal }}
     - name: Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: /home/runner/.cabal/store/ghc-${{ matrix.ghc-ver }}
         # Prefer previous SHA hash if it is still cached

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-/.stack-work
-/TAGS
-/stack.yaml
 /dist-newstyle
 /cabal.project.freeze
 /cabal.project.local

--- a/README.md
+++ b/README.md
@@ -1,23 +1,7 @@
-<table>
-  <tr>
-    <th>License</th><th>Linux</th>
-  </tr>
-  <tr>
-    <td><a href="LICENSE"><img src="https://img.shields.io/badge/license-BSD-blue.svg" title="License"/></a></td>
-  </tr>
-</table>
-
 # elf-edit
-The elf-edit library provides a datatype suitable for reading and writing Elf files.
+
+The elf-edit library provides a datatype suitable for reading and writing ELF files.
 
 It is a fork of the original elf package on Hackage, but enables modifying
-and serializing Elf files.  These changes are not backwards compatible and hence
+and serializing ELF files.  These changes are not backwards compatible and hence
 we have a new name.
-
-## Building with Stack
-
-To build with Stack, first symlink to one of the provided YAML
-files. For example
-
-    ln -fs stack-8.6.yaml stack.yaml
-    stack build


### PR DESCRIPTION
- We don't build with `stack` in CI, so remove mention of it
- ELF is capitalized
- Remove weird/random HTML table in README