### PR TITLE
ci: Bump `checkout` action from v2 to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     name: GHC v${{ matrix.ghc-ver }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Copy cabal project files


### PR DESCRIPTION
I accidentally missed pushing this as part of #52.